### PR TITLE
[adguard-home] add pullpolicy to configmap

### DIFF
--- a/charts/stable/adguard-home/values.yaml
+++ b/charts/stable/adguard-home/values.yaml
@@ -15,6 +15,7 @@ initContainers:
 # @default -- See values.yaml
   copy-configmap:
     image: busybox
+    pullPolicy: IfNotPresent
     command:
     - "sh"
     - "-c"


### PR DESCRIPTION
If dont have adguard working no dns, cant pull the busybox image. Best use Ifnotpresent for configmap-init.
